### PR TITLE
[REFACTOR] allowedOrigins -> allowedOriginPatterns 수정

### DIFF
--- a/src/main/java/com/example/glowtales/config/CorsConfig.java
+++ b/src/main/java/com/example/glowtales/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true); // 내 서버가 응답할 때 json을 자바스크립트에서 처리할 수 있게 설정하는 것
-        config.addAllowedOrigin("*"); // 모든 ip에 응답을 허용
+        config.addAllowedOriginPattern("*"); // 모든 ip에 응답을 허용
         config.addAllowedHeader("*"); // 모든 header에 응답을 허용
         config.addAllowedMethod("*"); // 모든 http method (GET, POST, DELETE, PATCH) 요청 허용
         source.registerCorsConfiguration("/api/**", config);


### PR DESCRIPTION
### 👀 관련 이슈
java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header.

-> 스프링부트에서 cors 설정 시, allowedCredentials와 allowedOrigins를 동시에 사용 불가능 하다고 함

### ✨ 작업한 내용
allowedOrigins -> allowedOriginPatterns로 변경

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
