### PR TITLE
동화 생성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-mustache'
 
-
+    // Json
+    implementation group: 'org.json', name: 'json', version: '20240303'
     //스웨거
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }

--- a/src/main/java/com/example/glowtales/controller/TaleController.java
+++ b/src/main/java/com/example/glowtales/controller/TaleController.java
@@ -1,31 +1,40 @@
 package com.example.glowtales.controller;
 
+import com.example.glowtales.domain.ResultCode;
+import com.example.glowtales.dto.Result;
 import com.example.glowtales.dto.request.TaleRequest;
 import com.example.glowtales.dto.response.tale.*;
 import com.example.glowtales.service.MemberService;
+import com.example.glowtales.service.PromptService;
 import com.example.glowtales.service.TaleService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.multipart.MultipartFile;
 
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/tale")
+@RequestMapping("/api/v1/tales")
 @Tag(name = "Tale API", description = "API for managing tales")
 public class TaleController {
 
+
+//#011 동화의 퀴즈와 정답 불러오기
+//#013 사용자 학습 언어와 수준 조회 GET
+//#014 단일 동화 다국어로 조회 GET
+//result 사용해서 응답 형식 통일하기
 
 
     private final TaleService taleService;
@@ -33,6 +42,7 @@ public class TaleController {
     private final ObjectMapper objectMapper;
 
     private static final Logger logger = LoggerFactory.getLogger(TaleController.class);
+    private final PromptService promptService;
 
     @Operation(summary = "#001 전체 동화 상태창 조회", description = "홈 화면에 나타나는 상태를 불러오는 API입니다.")
     @GetMapping("/")
@@ -49,19 +59,19 @@ public class TaleController {
         if (count == null) {
             count = -1;//기본값 설정. 제한 없이 모든 동화를 불러옴
         }
-        List<TaleResponseDto> posts = taleService.getUnlearnedTaleByMemberId(accessToken,count);
+        List<TaleResponseDto> posts = taleService.getUnlearnedTaleByMemberId(accessToken, count);
         return ResponseEntity.ok(posts);
     }
 
 
     @Operation(summary = "#007 최근 학습한 동화 전체 조회", description = "최근 학습한 동화를 최신순으로 불러오는 API입니다.")
     @GetMapping("/studied")
-    public ResponseEntity<List<TaleResponseDto>> getStudiedTalesByMemberId(@RequestHeader(value = "Authorization", required = true) String accessToken,@RequestParam(name = "count", required = false) Integer count) {
+    public ResponseEntity<List<TaleResponseDto>> getStudiedTalesByMemberId(@RequestHeader(value = "Authorization", required = true) String accessToken, @RequestParam(name = "count", required = false) Integer count) {
         logger.info("Count value: {}", count);
         if (count == null) {
             count = -1;//기본값 설정. 제한 없이 모든 동화를 불러옴
         }
-        List<TaleResponseDto> posts = taleService.getStudiedTaleByMemberId(accessToken,count);
+        List<TaleResponseDto> posts = taleService.getStudiedTaleByMemberId(accessToken, count);
         return ResponseEntity.ok(posts);
     }
 
@@ -72,7 +82,7 @@ public class TaleController {
         if (count == null) {
             count = -1;//기본값 설정. 제한 없이 모든 동화를 불러옴
         }
-        List<WordResponseDto> words = taleService.getWordByMemberId(accessToken,count);
+        List<WordResponseDto> words = taleService.getWordByMemberId(accessToken, count);
         return ResponseEntity.ok(words);
     }
 
@@ -104,9 +114,9 @@ public class TaleController {
 
     @Operation(summary = "#015 단일 동화 다국어로 조회", description = "TaleId와 languageId를 통해 단일 동화를 조회하는 API입니다. 동화 생성 후 언어를 바꿀때 사용합니다.1 = 영어 , 2 = 한국어 , 3 = 일본어 , 4 = 중국어")
     @GetMapping("/detail/lan")
-    public ResponseEntity<LanguageTaleDetailResponseDto> getTaleBylanguageTaleIdLanguageId(@RequestHeader(value = "Authorization", required = true) String accessToken, @RequestParam Long taleId,Long languageId) {
+    public ResponseEntity<LanguageTaleDetailResponseDto> getTaleBylanguageTaleIdLanguageId(@RequestHeader(value = "Authorization", required = true) String accessToken, @RequestParam Long taleId, Long languageId) {
         try {
-            LanguageTaleDetailResponseDto response = taleService.getTaleBylanguageTaleIdLanguageId( accessToken,  taleId, languageId);
+            LanguageTaleDetailResponseDto response = taleService.getTaleBylanguageTaleIdLanguageId(accessToken, taleId, languageId);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             e.printStackTrace();
@@ -117,46 +127,58 @@ public class TaleController {
 
 
     @Operation(summary = "#008 동화 만들기", description = "동화를 만드는 API입니다.")
-    @PostMapping("/new")
-    public ResponseEntity<TaleDetailResponseDto> TaleRequest(@RequestBody TaleRequest request) {
+    @PostMapping("/")
+    public Result createTales(
+            @RequestBody @Valid TaleRequest taleRequest,
+            @RequestHeader(value = "Authorization", required = false) String accessToken) {
+        try {
 
-        TaleDetailResponseDto responseDto = TaleDetailResponseDto.builder()
-                .taleId(1L)
-                .title("재영이와 구름 위의 코끼리") // 예시 제목
-                .language("Ko") // 예시 언어
-                .story("여름의 어느 날, 재영이는 시원한 바람을 맞으며 공원에 놀러 갔어.\n" +
-                        "푸른 하늘을 올려다보던 재영이는 구름 속에서 무언가 움직이는 걸 보았어.\n" +
-                        "\"구름 속에 뭐가 있을까?\" 재영이는 호기심이 가득했지.\n" +
-                        "갑자기, 구름이 빵빵 터지면서 커다란 코끼리가 하늘에서 내려왔어!\n" +
-                        "코끼리는 뾰족한 파란 모자를 쓰고 있었고, 하늘을 떠다니며 춤을 추고 있었지.\n" +
-                        "재영이는 눈을 의심하며 \"코끼리가 구름 위에서 춤추고 있어?!\"라고 외쳤어.\n" +
-                        "코끼리는 공중에서 솜사탕처럼 둥둥 떠다니며 재영에게 손을 흔들었어.\n" +
-                        "\"안녕! 난 클라우드코!\" 코끼리가 신나게 인사했어.\n" +
-                        "재영이는 \"클라우드코? 정말 기이한 이름이네!\"라며 웃었어.\n" +
-                        "클라우드코는 유쾌하게 웃으며 \"그래! 난 여름 구름의 특별한 코끼리야!\"라고 했어.\n" +
-                        "재영이는 \"여름에 구름 위에서 뭐 하는 거야?\"라고 물었어.\n" +
-                        "클라우드코는 \"구름 위에서 파티를 열고, 사람들에게 웃음을 주는 게 내 일이야!\"라고 답했어.\n" +
-                        "\"진짜? 그럼 나도 파티에 초대해줘!\" 재영이가 신나게 말했어.\n" +
-                        "클라우드코는 재영을 구름으로 초대하며 \"그럼, 나와 함께 구름 파티를 즐기자!\"라고 했어.\n" +
-                        "재영이는 클라우드코의 등에 올라타서 구름 속으로 올라갔어.\n" +
-                        "구름 속에 도착하자, 다양한 색깔의 구름과 기발한 장식들이 있었어.\n" +
-                        "사람들은 구름 위에서 춤을 추고, 코끼리들이 연주하는 음악에 맞춰 즐기고 있었지.\n" +
-                        "재영이는 구름 위에서 흥겹게 춤을 추며 기분이 좋았어.\n" +
-                        "클라우드코는 재영에게 특별한 구름 음료를 건네며 \"이건 구름에서 만든 음료야!\"라고 했어.\n" +
-                        "재영이는 음료를 마시며 \"이 음료, 너무 맛있어!\"라고 놀라워했어.\n" +
-                        "그때, 구름 위에서 작은 소리가 들렸어. \"도와줘! 나 떨어질 것 같아!\"\n" +
-                        "재영이와 클라우드코는 소리가 나는 쪽으로 달려갔어.\n" +
-                        "작은 구름이 바람에 휘날리며 떨어지려고 하고 있었어.\n" +
-                        "클라우드코는 재영이에게 \"작은 구름을 잡아줘!\"라고 했어.\n" +
-                        "재영이는 용감하게 작은 구름을 잡아서 하늘로 다시 올려보냈어.\n" +
-                        "작은 구름은 감사하며 \"고마워! 이제 안전해!\"라고 말했어.\n" +
-                        "클라우드코는 재영이에게 \"멋진 영웅이네!\"라고 칭찬했어.\n" +
-                        "재영이는 부끄러워하며 \"그냥 작은 도움이었을 뿐이야!\"라고 말했어.\n" +
-                        "파티가 끝나갈 무렵, 클라우드코는 재영이에게 \"이제 돌아갈 시간이야. 하지만 언제든지 구름 속으로 놀러와!\"라고 했어.\n" +
-                        "재영이는 행복하게 고개를 끄덕이며 \"고마워, 클라우드코! 꼭 다시 올게!\"라고 인사하며 구름에서 내려왔어.") // 예시 내용
-                .build();
-
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+            return new Result(ResultCode.SUCCESS, taleService.createLanguageTales(taleRequest, accessToken));
+        } catch (Exception e) {
+            return new Result(ResultCode.FAIL, e.getMessage(), "400");
+        }
     }
 
+//    @Operation(summary = "#008 동화 만들기", description = "동화를 만드는 API입니다.")
+//    @PostMapping("/new")
+//    public ResponseEntity<TaleDetailResponseDto> TaleRequest(@RequestBody TaleRequest request) {
+//
+//        TaleDetailResponseDto responseDto = TaleDetailResponseDto.builder()
+//                .taleId(1L)
+//                .title("재영이와 구름 위의 코끼리") // 예시 제목
+//                .language("Ko") // 예시 언어
+//                .story("여름의 어느 날, 재영이는 시원한 바람을 맞으며 공원에 놀러 갔어.\n" +
+//                        "푸른 하늘을 올려다보던 재영이는 구름 속에서 무언가 움직이는 걸 보았어.\n" +
+//                        "\"구름 속에 뭐가 있을까?\" 재영이는 호기심이 가득했지.\n" +
+//                        "갑자기, 구름이 빵빵 터지면서 커다란 코끼리가 하늘에서 내려왔어!\n" +
+//                        "코끼리는 뾰족한 파란 모자를 쓰고 있었고, 하늘을 떠다니며 춤을 추고 있었지.\n" +
+//                        "재영이는 눈을 의심하며 \"코끼리가 구름 위에서 춤추고 있어?!\"라고 외쳤어.\n" +
+//                        "코끼리는 공중에서 솜사탕처럼 둥둥 떠다니며 재영에게 손을 흔들었어.\n" +
+//                        "\"안녕! 난 클라우드코!\" 코끼리가 신나게 인사했어.\n" +
+//                        "재영이는 \"클라우드코? 정말 기이한 이름이네!\"라며 웃었어.\n" +
+//                        "클라우드코는 유쾌하게 웃으며 \"그래! 난 여름 구름의 특별한 코끼리야!\"라고 했어.\n" +
+//                        "재영이는 \"여름에 구름 위에서 뭐 하는 거야?\"라고 물었어.\n" +
+//                        "클라우드코는 \"구름 위에서 파티를 열고, 사람들에게 웃음을 주는 게 내 일이야!\"라고 답했어.\n" +
+//                        "\"진짜? 그럼 나도 파티에 초대해줘!\" 재영이가 신나게 말했어.\n" +
+//                        "클라우드코는 재영을 구름으로 초대하며 \"그럼, 나와 함께 구름 파티를 즐기자!\"라고 했어.\n" +
+//                        "재영이는 클라우드코의 등에 올라타서 구름 속으로 올라갔어.\n" +
+//                        "구름 속에 도착하자, 다양한 색깔의 구름과 기발한 장식들이 있었어.\n" +
+//                        "사람들은 구름 위에서 춤을 추고, 코끼리들이 연주하는 음악에 맞춰 즐기고 있었지.\n" +
+//                        "재영이는 구름 위에서 흥겹게 춤을 추며 기분이 좋았어.\n" +
+//                        "클라우드코는 재영에게 특별한 구름 음료를 건네며 \"이건 구름에서 만든 음료야!\"라고 했어.\n" +
+//                        "재영이는 음료를 마시며 \"이 음료, 너무 맛있어!\"라고 놀라워했어.\n" +
+//                        "그때, 구름 위에서 작은 소리가 들렸어. \"도와줘! 나 떨어질 것 같아!\"\n" +
+//                        "재영이와 클라우드코는 소리가 나는 쪽으로 달려갔어.\n" +
+//                        "작은 구름이 바람에 휘날리며 떨어지려고 하고 있었어.\n" +
+//                        "클라우드코는 재영이에게 \"작은 구름을 잡아줘!\"라고 했어.\n" +
+//                        "재영이는 용감하게 작은 구름을 잡아서 하늘로 다시 올려보냈어.\n" +
+//                        "작은 구름은 감사하며 \"고마워! 이제 안전해!\"라고 말했어.\n" +
+//                        "클라우드코는 재영이에게 \"멋진 영웅이네!\"라고 칭찬했어.\n" +
+//                        "재영이는 부끄러워하며 \"그냥 작은 도움이었을 뿐이야!\"라고 말했어.\n" +
+//                        "파티가 끝나갈 무렵, 클라우드코는 재영이에게 \"이제 돌아갈 시간이야. 하지만 언제든지 구름 속으로 놀러와!\"라고 했어.\n" +
+//                        "재영이는 행복하게 고개를 끄덕이며 \"고마워, 클라우드코! 꼭 다시 올게!\"라고 인사하며 구름에서 내려왔어.") // 예시 내용
+//                .build();
+//
+//        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+//    }
 }

--- a/src/main/java/com/example/glowtales/domain/LanguageTale.java
+++ b/src/main/java/com/example/glowtales/domain/LanguageTale.java
@@ -3,10 +3,10 @@ package com.example.glowtales.domain;
 import com.example.glowtales.converter.YesOrNoConverter;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.sql.Clob;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,8 +27,8 @@ public class LanguageTale {
     @JoinColumn(name = "tale_id")
     private Tale tale;
 
-    @Lob
-    private Clob story;
+    @Column(columnDefinition = "TEXT")
+    private String story;
 
     private String title;
 
@@ -39,4 +39,13 @@ public class LanguageTale {
     @OneToMany(mappedBy = "languageTale", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Quiz> quizList = new ArrayList<>();
 
+    @Builder
+    public LanguageTale(Language language, Tale tale, String story, String title, YesOrNo isLearned, Integer count) {
+        this.language = language;
+        this.tale = tale;
+        this.story = story;
+        this.title = title;
+        this.isLearned = isLearned;
+        this.count = count;
+    }
 }

--- a/src/main/java/com/example/glowtales/domain/Tale.java
+++ b/src/main/java/com/example/glowtales/domain/Tale.java
@@ -38,5 +38,7 @@ public class Tale {
     @OneToMany(mappedBy = "tale", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TaleWord> taleWordList = new ArrayList<>();
 
-
+    public Tale(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/com/example/glowtales/dto/request/TaleRequest.java
+++ b/src/main/java/com/example/glowtales/dto/request/TaleRequest.java
@@ -1,5 +1,6 @@
 package com.example.glowtales.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,9 +9,13 @@ import java.util.List;
 @Getter
 @Setter
 public class TaleRequest {
-    private List<String> keywords;
+    @NotBlank
     private String detail;
+    @NotBlank
     private String mood;
-    private String characters;
+    private List<String> characters;
+    @NotBlank
     private String contents;
+    @NotBlank
+    private List<String> keywords;
 }

--- a/src/main/java/com/example/glowtales/dto/response/tale/TaleDetailResponseDto.java
+++ b/src/main/java/com/example/glowtales/dto/response/tale/TaleDetailResponseDto.java
@@ -1,7 +1,9 @@
 package com.example.glowtales.dto.response.tale;
 
+import com.example.glowtales.domain.Language;
 import com.example.glowtales.domain.LanguageTale;
 import com.example.glowtales.domain.Tale;
+import com.example.glowtales.domain.YesOrNo;
 import jakarta.persistence.Lob;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,12 +17,9 @@ import java.util.Optional;
 @Setter
 public class TaleDetailResponseDto {
     private Long taleId;
+    private Long languageTaleId;
     private String title;
-    private String language;
-//    @Lob
-//    private Clob story;
-
-    //test 반환용 코드
+    private String languageName;
     private String story;
 
 //    @Builder
@@ -43,12 +42,40 @@ public class TaleDetailResponseDto {
 //
 //    }
 
-//test 객체 반환용 코드
+    //test 객체 반환용 코드
     @Builder
-    public TaleDetailResponseDto(Long taleId, String title, String language, String story) {
+    public TaleDetailResponseDto(Long taleId, Long languageTaleId, String title, String languageName, String story) {
         this.taleId = taleId;
+        this.languageTaleId = languageTaleId;
         this.title = title;
-        this.language = language;
+        this.languageName = languageName;
         this.story = story;
+    }
+
+    public TaleDetailResponseDto(String title, String languageName, String story) {
+        this.title = title;
+        this.languageName = languageName;
+        this.story = story;
+    }
+
+    public static TaleDetailResponseDto of(LanguageTale languageTale, Tale tale) {
+        return TaleDetailResponseDto.builder()
+                .languageTaleId(languageTale.getId())
+                .taleId(tale.getId())
+                .title(languageTale.getTitle())
+                .languageName(languageTale.getLanguage().getLanguageName())
+                .story(languageTale.getStory())
+                .build();
+    }
+
+    public static LanguageTale to(TaleDetailResponseDto taleDetailResponseDto, Tale tale, Language language) {
+        return LanguageTale.builder()
+                .language(language)
+                .tale(tale)
+                .isLearned(YesOrNo.NO)
+                .count(0)
+                .title(taleDetailResponseDto.getTitle())
+                .story(taleDetailResponseDto.getStory())
+                .build();
     }
 }

--- a/src/main/java/com/example/glowtales/repository/LanguageRepository.java
+++ b/src/main/java/com/example/glowtales/repository/LanguageRepository.java
@@ -3,5 +3,6 @@ package com.example.glowtales.repository;
 import com.example.glowtales.domain.Language;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LauguageRepository extends JpaRepository<Language, Long> {
+public interface LanguageRepository extends JpaRepository<Language, Long> {
+    Language findByLanguageName(String languageName);
 }

--- a/src/main/java/com/example/glowtales/service/MemberService.java
+++ b/src/main/java/com/example/glowtales/service/MemberService.java
@@ -5,7 +5,7 @@ import com.example.glowtales.domain.LearningLanguage;
 import com.example.glowtales.domain.Member;
 import com.example.glowtales.dto.request.MemberForm;
 import com.example.glowtales.dto.response.member.LearningLanguageResponseDto;
-import com.example.glowtales.repository.LauguageRepository;
+import com.example.glowtales.repository.LanguageRepository;
 import com.example.glowtales.repository.LearningLanguageRepository;
 import com.example.glowtales.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final LauguageRepository lauguageRepository;
+    private final LanguageRepository languageRepository;
     private final LearningLanguageRepository learningLanguageRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -44,7 +44,7 @@ public class MemberService {
         // learningLanguage 저장
        learningLanguageRepository.save(
                LearningLanguage.builder()
-                .language(lauguageRepository.findById(memberForm.getLanguageId()).orElseThrow(() -> new NoSuchElementException("일치하는 언어가 존재하지 않습니다.")))
+                .language(languageRepository.findById(memberForm.getLanguageId()).orElseThrow(() -> new NoSuchElementException("일치하는 언어가 존재하지 않습니다.")))
                 .member(member)
                 .learningLevel(memberForm.getLearningLevel())
                 .build()

--- a/src/main/java/com/example/glowtales/service/PromptService.java
+++ b/src/main/java/com/example/glowtales/service/PromptService.java
@@ -1,0 +1,198 @@
+package com.example.glowtales.service;
+
+import com.example.glowtales.domain.Member;
+import com.example.glowtales.dto.request.TaleRequest;
+import com.example.glowtales.dto.response.tale.TaleDetailResponseDto;
+import com.example.glowtales.repository.LanguageRepository;
+import com.example.glowtales.repository.LanguageTaleRepository;
+import com.example.glowtales.repository.TaleRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+
+    private final TaleRepository taleRepository;
+    private final LanguageTaleRepository languageTaleRepository;
+    private final LanguageRepository languageRepository;
+
+    @Value("${chatgpt.api-key}")
+    private String apiKey;
+
+    @Value("${chatgpt.api-url}")
+    private String apiUrl;
+
+    @Value("${chatgpt.model}")
+    private String model;
+
+    public List<TaleDetailResponseDto> createInitialTales(TaleRequest taleRequest, Member member) {
+        String prompt =
+                "Please generate a fairy tale in JSON format based on the following inputs:\n" +
+                        "Atmosphere:" + taleRequest.getMood() + "\n" +
+                        "Characters:" + taleRequest.getCharacters() + "(e.g., a brave knight, a curious fox, a kind witch)\n" +
+                        "Main Plot/Theme: " + taleRequest.getContents() + "(e.g., a quest for hidden treasure, a journey to discover friendship)\n" +
+                        "Reader's Age:" + member.getAge() + " years old\n" +
+                        "Preferred Language: English, Korean, Chinese, Japanese\n" +
+                        "Keyword: " + taleRequest.getKeywords() + "\n" +
+                        """
+                                Please generate a fairy tale that adheres to the following requirements:
+                                
+                                 1. Length: The story should be at least 35 sentences and no more than 50 sentences.
+                                 2. Age Appropriateness: Tailor the language, themes, and content to be suitable for the reader's age.
+                                 3. Dynamic Content: The story should reflect the atmosphere, characters, main plot/theme, and keyword provided.
+                                 4. Title: Generate a suitable title for the fairy tale in the specified languages.
+                                 5. JSON Format: The output should be in JSON format as shown below.
+                                
+                                 Expected JSON Format:
+                                
+                                 [
+                                   {
+                                     "language": "English",
+                                     "title": "The Lost Kingdom of Glimmervale",
+                                     "story": "Once upon a time, in a magical land, there was a brave knight named Sir Cedric..."
+                                   },
+                                   {
+                                     "language": "Korean",
+                                     "title": "잃어버린 왕국",
+                                     "story": "옛날 옛적에, 마법의 땅에 용감한 기사 세드릭이 살고 있었어요..."
+                                   },
+                                   {
+                                     "language": "Chinese",
+                                     "title": "失落的王国",
+                                     "story": "很久很久以前，在一个魔法的土地上，有一位勇敢的骑士名叫赛德里克..."
+                                   },
+                                   {
+                                     "language": "Japanese",
+                                     "title": "失われた王国",
+                                     "story": "昔々、魔法の国にセドリックという勇敢な騎士がいました..."
+                                   }
+                                 ]
+                                """;
+
+
+        return getStories(getChatResponse(prompt));
+    }
+
+    public List<TaleDetailResponseDto> test() {
+        String prompt = "Please generate a fairy tale based on the following inputs:\n" +
+                "\n" +
+                "Atmosphere: Magical\n" +
+                "Characters: A brave knight, a wise owl, an enchanted tree\n" +
+                "Main Plot/Theme: A quest to find a lost kingdom\n" +
+                "Reader's Age: 10 years old\n" +
+                "Preferred Language: English, Korean\n" +
+                "Keyword: A glowing crystal\n" +
+                """
+                        Please generate a fairy tale that adheres to the following requirements:
+                        
+                         1. Length: The story should be at least 35 sentences and no more than 50 sentences.
+                         2. Age Appropriateness: Tailor the language, themes, and content to be suitable for the reader's age.
+                         3. Dynamic Content: The story should reflect the atmosphere, characters, main plot/theme, and keyword provided.
+                         4. Title: Generate a suitable title for the fairy tale in the specified languages.
+                         5. Formatting: Separate each sentence with a newline character "\n".
+                         6. JSON Format: The output should be in JSON format as shown below.
+                        
+                         Expected JSON Format:
+                        
+                         [
+                           {
+                             "language": "English",
+                             "title": "The Lost Kingdom of Glimmervale",
+                             "story": "Once upon a time, in a magical land, there was a brave knight named Sir Cedric..."
+                           },
+                           {
+                             "language": "Korean",
+                             "title": "잃어버린 왕국",
+                             "story": "옛날 옛적에, 마법의 땅에 용감한 기사 세드릭이 살고 있었어요..."
+                           },
+                           {
+                             "language": "Chinese",
+                             "title": "失落的王国",
+                             "story": "很久很久以前，在一个魔法的土地上，有一位勇敢的骑士名叫赛德里克..."
+                           },
+                           {
+                             "language": "Japanese",
+                             "title": "失われた王国",
+                             "story": "昔々、魔法の国にセドリックという勇敢な騎士がいました..."
+                           }
+                         ]
+                        """;
+        return getStories(getChatResponse(prompt));
+    }
+
+    private String getChatResponse(String prompt) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + apiKey);
+        headers.set("Content-Type", "application/json");
+
+        Map<String, Object> requestBody = Map.of(
+                "model", model,
+                "messages", List.of(Map.of("role", "user", "content", prompt))
+//                "max_tokens", 1500
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(apiUrl, HttpMethod.POST, entity, String.class);
+        System.out.println("response: " + response.getBody());
+        return response.getBody();
+    }
+
+    public List<TaleDetailResponseDto> getStories(String responseBody) {
+        try {
+            // JSON 응답에서 'content' 값을 추출
+            String content = extractContent(responseBody);
+
+            // JSON 문자열을 JSONArray로 변환하고 각 항목을 출력
+            org.json.JSONArray jsonArray = new JSONArray(content);
+
+            List<TaleDetailResponseDto> tales = new ArrayList<>();
+
+            for (int i = 0; i < jsonArray.length(); i++) {
+                JSONObject jsonObject = jsonArray.getJSONObject(i);
+                System.out.println("title: " + jsonObject.optString("title", "Untitled"));
+                System.out.println("language: " + jsonObject.optString("language", "Unknown"));
+                System.out.println("story: " + jsonObject.optString("story", "No story available"));
+                tales.add(
+                        new TaleDetailResponseDto(
+                                jsonObject.optString("title", "Untitled"),
+                                jsonObject.optString("language", "Unknown"),
+                                jsonObject.optString("story", "No story available")
+                        ));
+            }
+            return tales;
+        } catch (Exception e) {
+            e.printStackTrace();  // 로깅 또는 적절한 예외 처리 필요
+        }
+        return new ArrayList<>();
+    }
+
+    // 'content' 값을 추출하는 메서드
+    private String extractContent(String responseBody) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = mapper.readTree(responseBody);
+        JsonNode contentNode = rootNode.path("choices").get(0).path("message").path("content");
+        System.out.println("content: " + contentNode);
+        return contentNode.asText().replace("```json", "").replace("```", "").trim();
+    }
+
+
+}


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
chatgpt를 이용하여 동화를 생성하고 동화 객체를 만들어 id를 반환하는 API 구현

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

- [ ] 동화 생성 시 필요한 파라미터를 받아
- [ ] 프롬프트를 생성하고
- [ ] chatgpt API를 이용하여 동화를 4개 국어로 생성 후
- [ ] 생성된 tale id를 반환하도록 구현

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
계속 chatgpt에서 요청한 형식과는 다른 json 형식을 제공하는 버그가 발생하여 보완이 필요합니다.
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|동화 생성 API 실행 시|![스크린샷 2024-08-22 오전 1 51 33](https://github.com/user-attachments/assets/57bd840a-fec7-44f1-814c-5c0418f93d8a)|
|DB에 잘 들어간 우리의 동화들...|<img width="564" alt="스크린샷 2024-08-22 오전 1 52 17" src="https://github.com/user-attachments/assets/3ca5af9e-092c-40bb-9ea7-933bde584e62">|

