### PR TITLE
[FIX] 미학습/학습 동화 반환 dto 분리, 한국어 title 추가

### DIFF
--- a/src/main/java/com/example/glowtales/controller/TaleController.java
+++ b/src/main/java/com/example/glowtales/controller/TaleController.java
@@ -69,12 +69,12 @@ public class TaleController {
 
     @Operation(summary = "#007 최근 학습한 동화 전체 조회", description = "최근 학습한 동화를 최신순으로 불러오는 API입니다.count는 limit을 의미하며, koreanVersion 은 홈/학습하기 화면에서 쓰이는 조건입니다.(홈/학습하기에는 한국어 버전의 동화만 보이며 미리보기로 화면에 보이는 동화의 수가 제한되어있음)")
     @GetMapping("/studied")
-    public Result<List<TaleResponseDto>> getStudiedTalesByMemberId(@RequestHeader(value = "Authorization", required = true) String accessToken, @RequestParam(name = "count", required = false) Integer count, @RequestParam Boolean koreanVersion) {
+    public Result<List<TaleWithKoreanTitleResponseDto>> getStudiedTalesByMemberId(@RequestHeader(value = "Authorization", required = true) String accessToken, @RequestParam(name = "count", required = false) Integer count, @RequestParam Boolean koreanVersion) {
         try {
             if (count == null) {
                 count = -1;//기본값 설정. 제한 없이 모든 동화를 불러옴
             }
-            List<TaleResponseDto> posts = taleService.getStudiedTaleByMemberId(accessToken, count, koreanVersion);
+            List<TaleWithKoreanTitleResponseDto> posts = taleService.getStudiedTaleByMemberId(accessToken, count, koreanVersion);
             return new Result(ResultCode.SUCCESS, posts);
         } catch (Exception e) {
             return new Result(ResultCode.FAIL, e.getMessage(), "400");

--- a/src/main/java/com/example/glowtales/dto/response/tale/TaleWithKoreanTitleResponseDto.java
+++ b/src/main/java/com/example/glowtales/dto/response/tale/TaleWithKoreanTitleResponseDto.java
@@ -6,25 +6,28 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Getter
 @Setter
-public class TaleResponseDto {
+public class TaleWithKoreanTitleResponseDto {
     private Long tale_id;
     private String createdAt;
     private LanguageTaleTitleResponseDto languageTale;
     private Long languageId;
+    private Integer firstQuizCount;
+    private String koreanTitle;
 
     @Builder
-    public TaleResponseDto(LanguageTale languageTale) {
+    public TaleWithKoreanTitleResponseDto(LanguageTale languageTale,String koreanTitle) {
         Tale tale=languageTale.getTale();
         this.tale_id = tale.getId();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd");
         this.createdAt = tale.getCreatedAt().format(formatter);
         this.languageTale = new LanguageTaleTitleResponseDto(languageTale);
+        this.firstQuizCount=languageTale.getFistQuizCount();
         this.languageId=languageTale.getLanguage().getId();
+        this.koreanTitle=koreanTitle;
 
     }
 }

--- a/src/main/java/com/example/glowtales/service/TaleService.java
+++ b/src/main/java/com/example/glowtales/service/TaleService.java
@@ -76,12 +76,15 @@ public class TaleService {
         List<Tale> tales = taleRepository.findByMemberId(member.getId());
 
         Stream<TaleResponseDto> taleResponseDtoStream = tales.stream()
+                .filter(tale -> koreaVersion
+                        ? tale.getLanguageTaleList().stream().allMatch(languageTale -> languageTale.getIsLearned().getValue() == 1)
+                        : true)
                 .flatMap(tale -> tale.getLanguageTaleList().stream()
                         .filter(languageTale -> (koreaVersion
                                 ? Objects.equals(languageTale.getLanguage().getLanguageName(), "Korean")
                                 : true) && languageTale.getIsLearned().getValue() == 1)
-                        .map(languageTale -> new TaleResponseDto(languageTale)))
-                .sorted(Comparator.comparing(TaleResponseDto::getTale_id)); // Optional: Sort if necessary
+                        .map(TaleResponseDto::new))
+                .sorted(Comparator.comparing(TaleResponseDto::getTale_id));
 
         if (count > 0) {
             taleResponseDtoStream = taleResponseDtoStream.limit(count);

--- a/src/main/java/com/example/glowtales/service/TaleService.java
+++ b/src/main/java/com/example/glowtales/service/TaleService.java
@@ -96,7 +96,7 @@ public class TaleService {
 
 
     //#007 최근 학습한 동화 조회
-    public List<TaleResponseDto> getStudiedTaleByMemberId(String accessToken, int count, boolean koreaVersion) {
+    public List<TaleWithKoreanTitleResponseDto> getStudiedTaleByMemberId(String accessToken, int count, boolean koreaVersion) {
         if (accessToken == null) {
             throw new RuntimeException("accessToken이 null입니다");
         }
@@ -106,13 +106,23 @@ public class TaleService {
         }
 
         List<Tale> tales = taleRepository.findByMemberId(member.getId());
-        Stream<TaleResponseDto> taleResponseDtoStream = tales.stream()
+        Stream<TaleWithKoreanTitleResponseDto> taleResponseDtoStream = tales.stream()
                 .flatMap(tale -> tale.getLanguageTaleList().stream()
                         .filter(languageTale -> (koreaVersion
                                 ? Objects.equals(languageTale.getLanguage().getLanguageName(), "Korean")
                                 : true) && languageTale.getIsLearned().getValue() == 0)
-                        .map(languageTale -> new TaleResponseDto(languageTale)))
-                .sorted(Comparator.comparing(TaleResponseDto::getTale_id)); // Optional: Sort if necessary
+                        .map(languageTale -> {
+                            // koreanTitle을 찾기 위해 languageId가 2인 객체 검색
+                            String koreanTitle = tale.getLanguageTaleList().stream()
+                                    .filter(lt -> lt.getLanguage().getId() == 2)
+                                    .map(LanguageTale::getTitle)
+                                    .findFirst()
+                                    .orElse(null);
+                            // TaleWithKoreanTitleResponseDto 생성
+                            return new TaleWithKoreanTitleResponseDto(languageTale, koreanTitle);
+                        }))
+                .sorted(Comparator.comparing(TaleWithKoreanTitleResponseDto::getTale_id)); // Optional: Sort if necessary
+
 
         if (count > 0) {
             taleResponseDtoStream = taleResponseDtoStream.limit(count);


### PR DESCRIPTION
### ✨ 작업한 내용
미학습/학습 동화 반환 dto 분리, 한국어 title 추가
미학습 동화 반환 시 조건 추가 - 4개국어 모두 미학습일때만 미학습으로 처리
### 🌀 PR Point


### 🍰 참고사항


### 📷 스크린샷 또는 GIF
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/ab75adff-ef26-4e52-a031-312591f90177">